### PR TITLE
Made CUtf8 methods const

### DIFF
--- a/src/c_utf8.rs
+++ b/src/c_utf8.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use c_char;
 use error::Error;
-use ext::Ext;
+use ext::is_nul_terminated;
 
 /// Like [`CStr`](https://doc.rust-lang.org/std/ffi/struct.CStr.html), except
 /// with the guarantee of being encoded as valid [UTF-8].
@@ -136,15 +136,33 @@ impl CUtf8 {
 
     /// Returns a C string containing `bytes`, or an error if a nul byte is in
     /// an unexpected position or if the bytes are not encoded as UTF-8.
+    ///
+    /// # Examples
+    /// ```
+    /// use c_utf8::{c_utf8, CUtf8, Error};
+    ///
+    /// let ok = &[0x6F, 0x6B, 0x00];
+    /// assert_eq!(CUtf8::from_bytes(ok), Ok(c_utf8!("ok")));
+    ///
+    /// let not_terminated = &[0x6F, 0x6B];
+    /// assert_eq!(CUtf8::from_bytes(not_terminated), Err(Error::Nul));
+    ///
+    /// let not_utf8 = &[0xFF, 0x00];
+    /// assert!(matches!(CUtf8::from_bytes(not_utf8), Err(Error::Utf8(_))));
+    /// ```
     #[inline]
-    pub fn from_bytes(bytes: &[u8]) -> Result<&CUtf8, Error> {
-        CUtf8::from_str(str::from_utf8(bytes)?)
+    pub const fn from_bytes(bytes: &[u8]) -> Result<&CUtf8, Error> {
+        // Can't use ? operator or Result::map in const functions
+        match str::from_utf8(bytes) {
+            Ok(str) => CUtf8::from_str(str),
+            Err(err) => Err(Error::Utf8(err))
+        }
     }
 
     /// Returns the UTF-8 string if it is terminated by a nul byte.
     #[inline]
-    pub fn from_str(s: &str) -> Result<&CUtf8, Error> {
-        if s.is_nul_terminated() {
+    pub const fn from_str(s: &str) -> Result<&CUtf8, Error> {
+        if is_nul_terminated(s.as_bytes()) {
             unsafe { Ok(CUtf8::from_str_unchecked(s)) }
         } else {
             Err(Error::Nul)
@@ -152,14 +170,33 @@ impl CUtf8 {
     }
 
     /// Returns the C string if it is valid UTF-8.
+    ///
+    /// # Examples
+    /// ```
+    /// use std::ffi::CStr;
+    /// use std::str::Utf8Error;
+    /// use c_utf8::*;
+    ///
+    /// let utf8 = CStr::from_bytes_with_nul(&[0x6F, 0x6B, 0x00]).unwrap();
+    /// assert_eq!(CUtf8::from_c_str(utf8), Ok(c_utf8!("ok")));
+    ///
+    /// let not_utf8 = CStr::from_bytes_with_nul(&[0xFF, 0x00]).unwrap();
+    /// assert_eq!(CUtf8::from_c_str(not_utf8).err(), not_utf8.to_str().err());
+    /// ```
     #[cfg(feature = "std")]
     #[inline]
-    pub fn from_c_str(c: &CStr) -> Result<&CUtf8, Utf8Error> {
-        let s = str::from_utf8(c.to_bytes_with_nul())?;
-        unsafe { Ok(CUtf8::from_str_unchecked(s)) }
+    pub const fn from_c_str(c: &CStr) -> Result<&CUtf8, Utf8Error> {
+        // Can't use ? operator or Result::map in const contexts
+        match str::from_utf8(c.to_bytes_with_nul()) {
+            Ok(s) => unsafe { Ok(CUtf8::from_str_unchecked(s)) }
+            Err(err) => Err(err)
+        }
     }
 
     /// Returns the raw C string if it is valid UTF-8 up to the first nul byte.
+    ///
+    /// # Safety
+    /// `raw` must satisfy all the safety requirements of [`CStr::from_ptr`].
     #[inline]
     pub unsafe fn from_ptr<'a>(raw: *const c_char) -> Result<&'a CUtf8, Utf8Error> {
         #[cfg(feature = "std")] {
@@ -198,7 +235,7 @@ impl CUtf8 {
     /// # }
     /// ```
     #[inline]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.0.len().wrapping_sub(1)
     }
 
@@ -216,72 +253,103 @@ impl CUtf8 {
     /// assert_eq!(s.len(), 0);
     /// ```
     #[inline]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.0.len() == 1
     }
 
     /// Returns a C string without checking UTF-8 validity or for a trailing
     /// nul byte.
+    ///
+    /// # Safety
+    /// `b` must be a nul-terminated UTF-8 string.
     #[inline]
-    pub unsafe fn from_bytes_unchecked(b: &[u8]) -> &CUtf8 {
+    pub const unsafe fn from_bytes_unchecked(b: &[u8]) -> &CUtf8 {
         &*(b as *const [u8] as *const CUtf8)
     }
 
     /// Returns a C string without checking for a trailing nul byte.
+    ///
+    /// # Safety
+    /// `s` must be nul-terminated.
     #[inline]
-    pub unsafe fn from_str_unchecked(s: &str) -> &CUtf8 {
+    pub const unsafe fn from_str_unchecked(s: &str) -> &CUtf8 {
         &*(s as *const str as *const CUtf8)
     }
 
     /// Returns a mutable C string without checking for a trailing nul byte.
+    ///
+    /// # Safety
+    /// `s` must be nul-terminated.
     #[inline]
     pub unsafe fn from_str_unchecked_mut(s: &mut str) -> &mut CUtf8 {
         &mut *(s as *mut str as *mut CUtf8)
     }
 
     /// Returns a C string without checking UTF-8 validity.
+    ///
+    /// # Safety
+    /// `c.to_bytes_with_null()` must be valid UTF-8.
     #[cfg(feature = "std")]
     #[inline]
-    pub unsafe fn from_c_str_unchecked(c: &CStr) -> &CUtf8 {
+    pub const unsafe fn from_c_str_unchecked(c: &CStr) -> &CUtf8 {
         Self::from_bytes_unchecked(c.to_bytes_with_nul())
     }
 
     /// Returns a pointer to the start of the raw C string.
     #[inline]
-    pub fn as_ptr(&self) -> *const c_char {
+    pub const fn as_ptr(&self) -> *const c_char {
         self.as_bytes().as_ptr() as *const c_char
     }
 
     /// Returns `self` as a normal C string.
     #[cfg(feature = "std")]
     #[inline]
-    pub fn as_c_str(&self) -> &CStr {
+    pub const fn as_c_str(&self) -> &CStr {
         unsafe { CStr::from_bytes_with_nul_unchecked(self.as_bytes_with_nul()) }
     }
 
     /// Returns `self` as a normal UTF-8 encoded string.
+    ///
+    /// # Examples
+    /// ```
+    /// use c_utf8::c_utf8;
+    /// assert_eq!(c_utf8!("hello").as_str(), "hello");
+    /// assert_ne!(c_utf8!("hello").as_str(), "hello\x00");
+    /// ```
     #[inline]
-    pub fn as_str(&self) -> &str {
+    pub const fn as_str(&self) -> &str {
         // Remove nul
         let len = self.0.len().saturating_sub(1);
-        unsafe { self.0.get_unchecked(..len) }
+        unsafe {
+            // Equivalent to get_unchecked(..len) but works in const contexts
+            let bytes: &[u8] = core::slice::from_raw_parts(self.0.as_ptr(), len);
+            str::from_utf8_unchecked(bytes)
+        }
     }
 
     /// Returns `self` as a UTF-8 encoded string with a trailing 0 byte.
+    ///
+    /// # Examples
+    /// ```
+    /// use c_utf8::c_utf8;
+    ///
+    /// assert_eq!(c_utf8!("hello").as_str_with_nul(), "hello\x00");
+    /// assert_ne!(c_utf8!("hello").as_str_with_nul(), "hello");
+    /// ```
     #[inline]
-    pub fn as_str_with_nul(&self) -> &str {
+    pub const fn as_str_with_nul(&self) -> &str {
         &self.0
     }
 
     /// Returns the bytes of `self` without a trailing 0 byte.
     #[inline]
-    pub fn as_bytes(&self) -> &[u8] {
+    pub const fn as_bytes(&self) -> &[u8] {
         self.as_str().as_bytes()
     }
 
     /// Returns the bytes of `self` with a trailing 0 byte.
     #[inline]
-    pub fn as_bytes_with_nul(&self) -> &[u8] {
+    pub const fn as_bytes_with_nul(&self) -> &[u8] {
         self.as_str_with_nul().as_bytes()
     }
 }

--- a/src/c_utf8_buf.rs
+++ b/src/c_utf8_buf.rs
@@ -226,6 +226,9 @@ impl CUtf8Buf {
 
     /// Creates a new C string from a native Rust string without checking for a
     /// nul terminator.
+    ///
+    /// # Safety
+    /// `s` must be nul-terminated.
     #[inline]
     pub unsafe fn from_string_unchecked(s: String) -> CUtf8Buf {
         CUtf8Buf(s)

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use core::str::Utf8Error;
 use std::ffi::FromBytesWithNulError;
 
 /// The error for converting types to [`CUtf8`](struct.CUtf8.html).
-#[derive(Clone, Debug)]
+#[derive(Copy, Eq, PartialEq, Clone, Debug)]
 pub enum Error {
     /// An error indicating that the nul byte was not at the end.
     Nul,
@@ -41,14 +41,6 @@ impl fmt::Display for Error {
 
 #[cfg(feature = "std")]
 impl ::std::error::Error for Error {
-    #[inline]
-    fn description(&self) -> &str {
-        match *self {
-            Error::Nul => NUL_ERROR,
-            Error::Utf8(ref err) => err.description(),
-        }
-    }
-
     #[inline]
     fn cause(&self) -> Option<&dyn (::std::error::Error)> {
         match *self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,7 +50,7 @@ impl ::std::error::Error for Error {
     }
 
     #[inline]
-    fn cause(&self) -> Option<&::std::error::Error> {
+    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
         match *self {
             Error::Utf8(ref err) => Some(err),
             _ => None,

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -12,6 +12,24 @@ impl Ext for str {
 impl Ext for [u8] {
     #[inline]
     fn is_nul_terminated(&self) -> bool {
-        self.last().cloned() == Some(0)
+        is_nul_terminated(self)
+    }
+}
+
+/// Returns `true` iff `bytes` is not empty and its last byte is `0`.
+pub const fn is_nul_terminated(bytes: &[u8]) -> bool {
+    matches!(bytes.last(), Some(0))
+}
+
+#[cfg(test)]
+mod test {
+    use ext::is_nul_terminated;
+
+    #[test]
+    fn test_is_nul_terminated() {
+        assert!(!is_nul_terminated(&[]));
+        assert!(!is_nul_terminated(&[1]));
+        assert!(is_nul_terminated(&[1, 0]));
+        assert!(!is_nul_terminated(&[0, 1]));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,12 +117,7 @@ use std as core;
 #[macro_export]
 macro_rules! c_utf8 {
     ($s:expr) => {
-        unsafe {
-            // An internal type that allows for converting static Rust string
-            // slices into static CUtf8 slices within a constant expression
-            union _Ref<'a> { s: &'a str, c: &'a $crate::CUtf8 }
-            _Ref { s: concat!($s, "\0") }.c
-        }
+        unsafe { $crate::CUtf8::from_str_unchecked(concat!($s, "\0")) }
     }
 }
 


### PR DESCRIPTION
Most non-mutating `CUtf8` methods can trivially be made `const`, which greatly increases the flexibility of the crate. The only changes required were:
* Two methods required de-sugaring the `?` operator since it uses `Into` to convert the error type
* The use of `Ext::is_nul_terminated` in `from_str` had to be replaced with an equivalent standalone const function (which the `Ext` implementation for `[u8]` now uses internally.)
*  `as_str` required replacing a call to `slice::get_unchecked` (which is not `const`) with a combination of `slice::from_raw_parts` and `str::from_utf8_unchecked`.

All methods that were changed had examples added to their rustdocs to ensure they still behave as expected.

Some other minor changes in this PR I'd like to call out:
* I added a dedicated **Safety** section to the docstrings of all `unsafe` methods to silence Clippy warnings.
* I added the `Copy`, `PartialEq` and `Eq` traits to `Error` since `Utf8Error` implements them and it made writing the examples easier.
* I deleted the implementation of `Error::description` since that method is now deprecated and was triggering a Clippy warning.